### PR TITLE
Add engines constraints and make them strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict = true
+strict-peer-deps = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,10 @@
         "ts-node": "^10.5.0",
         "tsconfig-paths": "^3.12.0",
         "typescript": "^4.5.5"
+      },
+      "engines": {
+        "node": "^17.5",
+        "npm": "^8.5"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "url": "https://github.com/TomFH/battleship/issues"
   },
   "homepage": "https://github.com/TomFH/battleship#readme",
+  "packageManager": "npm",
+  "engines": {
+    "node": "^17.5",
+    "npm": "^8.5"
+  },
   "devDependencies": {
     "@types/chai": "^4.3.0",
     "@types/mocha": "^9.1.0",


### PR DESCRIPTION
I will spare you the historic reasons as to why npm behaves that way but at the moment, by default, it will only issue a warning if the engine constraints are not met instead of an error. This IMO is quite bad as will most certainly result in unexpected and undesired behaviour. Hence this PR which changes this behaviour: if you have the wrong verision of node or npm doing an npm update/install/ci command will now fail.