### PR TITLE
Allow the grid to have a generic cell type

### DIFF
--- a/src/grid/grid.ts
+++ b/src/grid/grid.ts
@@ -4,22 +4,18 @@ import { assertIsNotUndefined } from '../assert/assert-is-not-undefined';
 import { Coordinate } from './coordinate';
 import assert = require('node:assert');
 
-export enum Cell {
-    EMPTY,
-    FULL,
-}
-
-export type Row<ColumnIndex extends PropertyKey> = Map<ColumnIndex, Cell>;
+export type Row<ColumnIndex extends PropertyKey, Cell> = Map<ColumnIndex, Cell>;
 
 export type GridRows<
     ColumnIndex extends PropertyKey,
     RowIndex extends PropertyKey,
-> = Map<RowIndex, Row<ColumnIndex>>;
+    Cell,
+> = Map<RowIndex, Row<ColumnIndex, Cell>>;
 
-function getRow<ColumnIndex extends PropertyKey, RowIndex extends PropertyKey>(
-    rows: Readonly<GridRows<ColumnIndex, RowIndex>>,
+function getRow<ColumnIndex extends PropertyKey, RowIndex extends PropertyKey, Cell>(
+    rows: Readonly<GridRows<ColumnIndex, RowIndex, Cell>>,
     rowIndex: RowIndex,
-): Row<ColumnIndex> {
+): Row<ColumnIndex, Cell> {
     const row = rows.get(rowIndex);
 
     assertIsNotUndefined(
@@ -33,8 +29,8 @@ function getRow<ColumnIndex extends PropertyKey, RowIndex extends PropertyKey>(
     return row;
 }
 
-function assertRowHasColumn<ColumnIndex extends PropertyKey>(
-    row: Readonly<Row<ColumnIndex>>,
+function assertRowHasColumn<ColumnIndex extends PropertyKey, Cell>(
+    row: Readonly<Row<ColumnIndex, Cell>>,
     columnIndex: ColumnIndex,
 ): void {
     assert(
@@ -54,23 +50,27 @@ function assertRowHasColumn<ColumnIndex extends PropertyKey>(
 export class Grid<
     ColumnIndex extends PropertyKey,
     RowIndex extends PropertyKey,
+    Cell,
 > {
     constructor(
-        readonly rows: Readonly<GridRows<ColumnIndex, RowIndex>>,
+        readonly rows: Readonly<GridRows<ColumnIndex, RowIndex, Cell>>,
     ) {
         assertAllRowsHaveSameColumns(rows);
     }
 
-    fillCells(coordinates: Array<Coordinate<ColumnIndex, RowIndex>>): Grid<ColumnIndex, RowIndex> {
+    fillCells(
+        coordinates: ReadonlyArray<Coordinate<ColumnIndex, RowIndex>>,
+        value: Cell,
+    ): Grid<ColumnIndex, RowIndex, Cell> {
         let rows = this.rows;
-        let row: Row<ColumnIndex>;
+        let row: Row<ColumnIndex, Cell>;
 
         coordinates.forEach(({ columnIndex, rowIndex }) => {
             row = getRow(rows, rowIndex);
 
             assertRowHasColumn(row, columnIndex);
 
-            row = row.set(columnIndex, Cell.FULL);
+            row = row.set(columnIndex, value);
 
             rows = rows.set(rowIndex, row);
         });
@@ -78,7 +78,7 @@ export class Grid<
         return new Grid(rows);
     }
 
-    getRows(): Readonly<GridRows<ColumnIndex, RowIndex>> {
+    getRows(): Readonly<GridRows<ColumnIndex, RowIndex, Cell>> {
         return this.rows;
     }
 }
@@ -86,7 +86,8 @@ export class Grid<
 function assertAllRowsHaveSameColumns<
     ColumnIndex extends PropertyKey,
     RowIndex extends PropertyKey,
->(rows: Readonly<GridRows<ColumnIndex, RowIndex>>): void {
+    Cell,m,
+>(rows: Readonly<GridRows<ColumnIndex, RowIndex, Cell>>): void {
     let columns: ColumnIndex[];
     let rowColumns: ColumnIndex[];
 

--- a/src/standard-grid/player-grid.ts
+++ b/src/standard-grid/player-grid.ts
@@ -1,8 +1,13 @@
 import { Map } from 'immutable';
-import { Cell, Grid, Row } from '../grid/grid';
+import { Grid, Row } from '../grid/grid';
 import { EnumHelper } from '../utils/enum-helper';
 import { ColumnIndex } from './column-index';
 import { RowIndex } from './row-index';
+
+enum Cell {
+    EMPTY,
+    FULL,
+}
 
 /**
  * Represents a player's grid, i.e. the grid the player owns and on which
@@ -10,7 +15,7 @@ import { RowIndex } from './row-index';
  */
 export class PlayerGrid {
     constructor(
-        private readonly innerGrid: Grid<ColumnIndex, RowIndex> = createEmptyGrid(),
+        private readonly innerGrid: Grid<ColumnIndex, RowIndex, Cell> = createEmptyGrid(),
     ) {
     }
 
@@ -27,7 +32,7 @@ export class PlayerGrid {
     // }
 }
 
-export function createEmptyRow(): Row<ColumnIndex> {
+export function createEmptyRow(): Row<ColumnIndex, Cell> {
     return Map(
         EnumHelper
             .getValues(ColumnIndex)
@@ -35,7 +40,7 @@ export function createEmptyRow(): Row<ColumnIndex> {
     );
 }
 
-export function createEmptyGrid(): Grid<ColumnIndex, RowIndex> {
+export function createEmptyGrid(): Grid<ColumnIndex, RowIndex, Cell> {
     const rows = Map(
         EnumHelper
             .getValues(RowIndex)

--- a/tests/grid/grid.spec.ts
+++ b/tests/grid/grid.spec.ts
@@ -3,18 +3,24 @@
 import { expect } from 'chai';
 import { Map } from 'immutable';
 import { Coordinate } from '../../src/grid/coordinate';
-import { Cell, Grid } from '../../src/grid/grid';
+import { Grid } from '../../src/grid/grid';
+
+enum Cell {
+    EMPTY,
+    FULL,
+}
 
 type GreekColumnIndex = 'α' | 'β';
 type JapaneseRowIndex = 'いち' | 'さん' | 'に';
 
-class GreekJapaneseGrid extends Grid<GreekColumnIndex, JapaneseRowIndex> {
+class GreekJapaneseGrid extends Grid<GreekColumnIndex, JapaneseRowIndex, Cell> {
 }
 
 function getGridRowsAsObject<
     ColumnIndex extends PropertyKey,
     RowIndex extends PropertyKey,
->(grid: Grid<ColumnIndex, RowIndex>): any {
+    Cell,
+>(grid: Grid<ColumnIndex, RowIndex, Cell>): any {
     return grid.getRows()
         .map((row) => row.toObject())
         .toObject();
@@ -256,7 +262,7 @@ describe('Grid filling', () => {
 
                 const sourceGrid = new GreekJapaneseGrid(rows);
 
-                const fillGrid = () => sourceGrid.fillCells(coordinates);
+                const fillGrid = () => sourceGrid.fillCells(coordinates, Cell.FULL);
 
                 const sourceGridRows = getGridRowsAsObject(sourceGrid);
 
@@ -272,7 +278,7 @@ describe('Grid filling', () => {
 
                 const sourceGrid = new GreekJapaneseGrid(rows);
 
-                const filledGrid = sourceGrid.fillCells(coordinates);
+                const filledGrid = sourceGrid.fillCells(coordinates, Cell.FULL);
 
                 const sourceGridRows = getGridRowsAsObject(sourceGrid);
                 const filledGridRows = getGridRowsAsObject(filledGrid);


### PR DESCRIPTION
Allow to set different values to a grid cells than the existing `Cell` enum. This will allow us for example to set pegs or ships instead of a simple empty/full cells.