### PR TITLE
CoordinateAlignment improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ run: dist/src/main.js
 .PHONY: test
 test:		## Runs the tests
 test: $(TEST_DEPS)
-	TS_NODE_PROJECT=tsconfig.tests.json npx mocha --require=ts-node/register --check-leaks --recursive "tests/**/*.spec.ts"
+	TS_NODE_PROJECT=tsconfig.tests.json npx mocha --require=ts-node/register --parallel --check-leaks --recursive "tests/**/*.spec.ts"
 
 
 .PHONY: benchmark

--- a/src/grid/coordinate-alignment.ts
+++ b/src/grid/coordinate-alignment.ts
@@ -185,10 +185,13 @@ export class CoordinateAlignment<
             return stringValue;
         }
 
-        const { direction, sortedCoordinates } = this;
+        const { direction, sortedCoordinates, nextHead, nextTail } = this;
         const formattedCoordinates = sortedCoordinates.map(toString).join(',');
 
-        stringValue = `${direction}:(${formattedCoordinates})`;
+        const leftSide = nextHead instanceof Coordinate ? ']' : '[';
+        const rightSide = nextTail instanceof Coordinate ? '[' : ']';
+
+        stringValue = `${direction}:${leftSide}${formattedCoordinates}${rightSide}`;
         this.stringValue = stringValue;
 
         return stringValue;

--- a/src/grid/coordinate-alignment.ts
+++ b/src/grid/coordinate-alignment.ts
@@ -28,10 +28,46 @@ export function completeAlignment<
     );
 }
 
+function recreateFromPreviousAlignment<
+    ColumnIndex extends PropertyKey,
+    RowIndex extends PropertyKey,
+>(
+    newSortedCoordinates: List<Coordinate<ColumnIndex, RowIndex>>,
+    previous: CoordinateAlignment<ColumnIndex, RowIndex>,
+    coordinateNavigator: CoordinateNavigator<ColumnIndex, RowIndex>,
+): CoordinateAlignment<ColumnIndex, RowIndex> {
+    const incompleteAlignment = {
+        direction: previous.direction,
+        coordinates: newSortedCoordinates,
+    };
+
+    const nextExtremums = coordinateNavigator.findNextExtremums(incompleteAlignment);
+
+    const nextHead = newSortedCoordinates.contains(previous.head)
+        ? previous.nextHead
+        : nextExtremums.nextHead;
+
+    const nextTail = newSortedCoordinates.contains(previous.tail)
+        ? previous.nextTail
+        : nextExtremums.nextTail;
+
+    return new CoordinateAlignment(
+        coordinateNavigator,
+        previous.direction,
+        newSortedCoordinates,
+        coordinateNavigator.findAlignmentGaps(incompleteAlignment),
+        nextHead,
+        nextTail,
+    );
+}
+
+export const RemovedNextExtremum = Symbol('RemovedNextExtremum');
+
 export class CoordinateAlignment<
     ColumnIndex extends PropertyKey,
     RowIndex extends PropertyKey,
 > implements ValueObject {
+    public readonly extremums: List<Coordinate<ColumnIndex, RowIndex>>;
     public readonly nextExtremums: List<Coordinate<ColumnIndex, RowIndex>>;
 
     private stringValue?: string;
@@ -41,15 +77,18 @@ export class CoordinateAlignment<
         public readonly direction: ShipDirection,
         public readonly sortedCoordinates: List<Coordinate<ColumnIndex, RowIndex>>,
         public readonly sortedGaps: List<Coordinate<ColumnIndex, RowIndex>>,
-        public readonly nextHead: Coordinate<ColumnIndex, RowIndex> | undefined,
-        public readonly nextTail: Coordinate<ColumnIndex, RowIndex> | undefined,
+        public readonly nextHead: Coordinate<ColumnIndex, RowIndex> | typeof RemovedNextExtremum | undefined,
+        public readonly nextTail: Coordinate<ColumnIndex, RowIndex> | typeof RemovedNextExtremum | undefined,
     ) {
         assert(
             sortedCoordinates.size >= 2,
             `Expected alignment to contain at least 2 elements. Got "${sortedCoordinates.size}".`,
         );
 
-        this.nextExtremums = List([nextHead, nextTail].filter(isNotUndefined));
+        this.extremums = List([this.head, this.tail].filter(isNotUndefined));
+        this.nextExtremums = List([nextHead, nextTail].filter(
+            (value): value is Coordinate<ColumnIndex, RowIndex> => value instanceof Coordinate),
+        );
     }
 
     get head(): Coordinate<ColumnIndex, RowIndex> {
@@ -64,6 +103,12 @@ export class CoordinateAlignment<
         return this.sortedCoordinates.includes(coordinate);
     }
 
+    containsAny(coordinates: List<Coordinate<ColumnIndex, RowIndex>>): boolean {
+        return coordinates.some(
+            (coordinate) => this.contains(coordinate),
+        );
+    }
+
     equals(other: unknown): boolean {
         return other instanceof CoordinateAlignment
             && this.toString() === other.toString();
@@ -74,27 +119,28 @@ export class CoordinateAlignment<
     }
 
     removeNextExtremum(extremum: Coordinate<ColumnIndex, RowIndex>): CoordinateAlignment<ColumnIndex, RowIndex> {
-        const { direction, sortedCoordinates, sortedGaps } = this;
+        const { extremums, head, tail } = this;
+
+        assert(
+            extremums.contains(extremum),
+            () => InvalidExtremum.forAlignment(this, extremum),
+        );
+
         let { nextHead, nextTail } = this;
 
-        const head = sortedCoordinates.first()!;
-
-        if (head.equals(extremum)) {
-            nextHead = undefined;
+        if (head.equals(extremum) && nextHead !== undefined) {
+            nextHead = RemovedNextExtremum;
+        } else if (tail.equals(extremum) && nextTail !== undefined) {
+            nextTail = RemovedNextExtremum;
         } else {
-            const tail = sortedCoordinates.last()!;
-
-            // Sanity check
-            assert(tail.equals(extremum));
-
-            nextTail = undefined;
+            return this;
         }
 
         return new CoordinateAlignment(
             this.coordinateNavigator,
-            direction,
-            sortedCoordinates,
-            sortedGaps,
+            this.direction,
+            this.sortedCoordinates,
+            this.sortedGaps,
             nextHead,
             nextTail,
         );
@@ -108,11 +154,9 @@ export class CoordinateAlignment<
         }
 
         return Either.right(
-            completeAlignment(
-                {
-                    direction: this.direction,
-                    coordinates: newSortedCoordinates,
-                },
+            recreateFromPreviousAlignment(
+                newSortedCoordinates,
+                this,
                 this.coordinateNavigator,
             ),
         );
@@ -126,11 +170,9 @@ export class CoordinateAlignment<
         }
 
         return Either.right(
-            completeAlignment(
-                {
-                    direction: this.direction,
-                    coordinates: newSortedCoordinates,
-                },
+            recreateFromPreviousAlignment(
+                newSortedCoordinates,
+                this,
                 this.coordinateNavigator,
             ),
         );
@@ -188,6 +230,22 @@ export class AtomicAlignment extends Error {
     }
 
     static forAlignment(alignment: CoordinateAlignment<any, any>): AtomicAlignment {
+        return new AtomicAlignment(`The alignment ${alignment.toString()} is atomic: no element can be removed from it.`);
+    }
+}
+
+
+export class InvalidExtremum extends Error {
+    constructor(message?: string) {
+        super(message);
+
+        this.name = 'InvalidExtremum';
+    }
+
+    static forAlignment(
+        alignment: CoordinateAlignment<any, any>,
+        extremum: Coordinate<any, any>,
+    ): AtomicAlignment {
         return new AtomicAlignment(`The alignment ${alignment.toString()} is atomic: no element can be removed from it.`);
     }
 }

--- a/tests/grid/coordinate-alignment.spec.ts
+++ b/tests/grid/coordinate-alignment.spec.ts
@@ -11,6 +11,97 @@ import {
     TestCoordinate, TestCoordinateAlignment, testCoordinateNavigator,
 } from './test-coordinates';
 
+class ToStringSet {
+    constructor(
+        readonly title: string,
+        readonly alignment: TestCoordinateAlignment,
+        readonly expected: string,
+    ) {
+    }
+}
+
+function* provideToStringSet(): Generator<ToStringSet> {
+    yield new ToStringSet(
+        'with extremums',
+        new CoordinateAlignment(
+            testCoordinateNavigator,
+            ShipDirection.HORIZONTAL,
+            List([
+                new Coordinate('B', '3'),
+                new Coordinate('C', '3'),
+            ]),
+            List([]),
+            new Coordinate('A', '3'),
+            new Coordinate('D', '3'),
+        ),
+        'HORIZONTAL:]B3,C3[',
+    );
+
+    yield new ToStringSet(
+        'with no left extremum',
+        new CoordinateAlignment(
+            testCoordinateNavigator,
+            ShipDirection.HORIZONTAL,
+            List([
+                new Coordinate('B', '3'),
+                new Coordinate('C', '3'),
+            ]),
+            List([]),
+            undefined,
+            new Coordinate('D', '3'),
+        ),
+        'HORIZONTAL:[B3,C3[',
+    );
+
+    yield new ToStringSet(
+        'with left removed',
+        new CoordinateAlignment(
+            testCoordinateNavigator,
+            ShipDirection.HORIZONTAL,
+            List([
+                new Coordinate('B', '3'),
+                new Coordinate('C', '3'),
+            ]),
+            List([]),
+            RemovedNextExtremum,
+            new Coordinate('D', '3'),
+        ),
+        'HORIZONTAL:[B3,C3[',
+    );
+
+    yield new ToStringSet(
+        'with no right extremum',
+        new CoordinateAlignment(
+            testCoordinateNavigator,
+            ShipDirection.HORIZONTAL,
+            List([
+                new Coordinate('B', '3'),
+                new Coordinate('C', '3'),
+            ]),
+            List([]),
+            new Coordinate('A', '3'),
+            undefined,
+        ),
+        'HORIZONTAL:]B3,C3]',
+    );
+
+    yield new ToStringSet(
+        'with no right extremum',
+        new CoordinateAlignment(
+            testCoordinateNavigator,
+            ShipDirection.HORIZONTAL,
+            List([
+                new Coordinate('B', '3'),
+                new Coordinate('C', '3'),
+            ]),
+            List([]),
+            new Coordinate('A', '3'),
+            RemovedNextExtremum,
+        ),
+        'HORIZONTAL:]B3,C3]',
+    );
+}
+
 class EqualitySet {
     constructor(
         readonly title: string,
@@ -193,8 +284,8 @@ function* provideExtremumRemoval(): Generator<ExtremumRemoval> {
             undefined,
             undefined,
         ),
-        'The alignment HORIZONTAL:(A4,B4) is atomic: no element can be removed from it.',
-        'The alignment HORIZONTAL:(A4,B4) is atomic: no element can be removed from it.',
+        'The alignment HORIZONTAL:[A4,B4] is atomic: no element can be removed from it.',
+        'The alignment HORIZONTAL:[A4,B4] is atomic: no element can be removed from it.',
     );
 
     yield new ExtremumRemoval(
@@ -436,23 +527,11 @@ function convertAlignment(alignment: TestCoordinateAlignment): object {
 }
 
 describe('Coordinate', () => {
-    it('can be cast into a string', () => {
-        const alignment = new CoordinateAlignment(
-            testCoordinateNavigator,
-            ShipDirection.HORIZONTAL,
-            List([
-                new Coordinate('A', '4'),
-                new Coordinate('B', '4'),
-            ]),
-            List([]),
-            undefined,
-            undefined,
-        );
-
-        const expected = 'HORIZONTAL:(A4,B4)';
-
-        expect(alignment.toString()).to.equal(expected);
-    });
+    for (const { title, alignment, expected } of provideToStringSet()) {
+        it(`can be cast into a string: ${title}`, () => {
+            expect(alignment.toString()).to.equal(expected);
+        });
+    }
 
     // This allows Immutable JS to correctly detect duplicates
     it('is an Immutable value object', () => {

--- a/tests/grid/coordinate-navigator.spec.ts
+++ b/tests/grid/coordinate-navigator.spec.ts
@@ -614,7 +614,7 @@ function* provideCoordinateAlignmentExplodeGapsSet(): Generator<CoordinateAlignm
             new Coordinate('A', '5'),
         ),
         [
-            'VERTICAL:(A1,A2,A3,A4)',
+            'VERTICAL:[A1,A2,A3,A4[',
         ],
     );
 
@@ -634,8 +634,8 @@ function* provideCoordinateAlignmentExplodeGapsSet(): Generator<CoordinateAlignm
             undefined,
         ),
         [
-            'VERTICAL:(A1,A2)',
-            'VERTICAL:(A4,A5)',
+            'VERTICAL:[A1,A2[',
+            'VERTICAL:]A4,A5]',
         ],
     );
 
@@ -655,7 +655,7 @@ function* provideCoordinateAlignmentExplodeGapsSet(): Generator<CoordinateAlignm
             undefined,
         ),
         [
-            'VERTICAL:(A1,A2,A3)',
+            'VERTICAL:[A1,A2,A3[',
         ],
     );
 }

--- a/tests/player/ai/opponent-ship.spec.ts
+++ b/tests/player/ai/opponent-ship.spec.ts
@@ -144,7 +144,7 @@ describe('OpponentShip', () => {
 
         expect(unverifiedSunkShip.status).to.equal(OpponentShipStatus.NON_VERIFIED_SUNK);
         expect(unverifiedSunkShip.alignment).to.equal(alignment);
-        expect(unverifiedSunkShip.toString()).to.equal('Battleship(4,NON_VERIFIED_SUNK,HORIZONTAL:(A2,B2,C2,D2))');
+        expect(unverifiedSunkShip.toString()).to.equal('Battleship(4,NON_VERIFIED_SUNK,HORIZONTAL:[A2,B2,C2,D2[)');
 
         expect(isNotFoundShip(unverifiedSunkShip)).to.equal(false);
         expect(isUnverifiedSunkShip(unverifiedSunkShip)).to.equal(true);
@@ -163,7 +163,7 @@ describe('OpponentShip', () => {
 
         expect(sunkShip.status).to.equal(OpponentShipStatus.SUNK);
         expect(sunkShip.alignment).to.equal(alignment);
-        expect(sunkShip.toString()).to.equal('Battleship(4,SUNK,HORIZONTAL:(A2,B2,C2,D2))');
+        expect(sunkShip.toString()).to.equal('Battleship(4,SUNK,HORIZONTAL:[A2,B2,C2,D2[)');
 
         expect(isNotFoundShip(sunkShip)).to.equal(false);
         expect(isUnverifiedSunkShip(sunkShip)).to.equal(false);
@@ -201,7 +201,7 @@ describe('OpponentShip', () => {
 
         expect(sunkShip.status).to.equal(OpponentShipStatus.SUNK);
         expect(sunkShip.alignment).to.equal(alignment);
-        expect(sunkShip.toString()).to.equal('Battleship(4,SUNK,HORIZONTAL:(A2,B2,C2,D2))');
+        expect(sunkShip.toString()).to.equal('Battleship(4,SUNK,HORIZONTAL:[A2,B2,C2,D2[)');
 
         expect(isNotFoundShip(sunkShip)).to.equal(false);
         expect(isUnverifiedSunkShip(sunkShip)).to.equal(false);

--- a/tests/standard-grid/std-ai-hit-strategy.spec.ts
+++ b/tests/standard-grid/std-ai-hit-strategy.spec.ts
@@ -161,7 +161,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.HIT, 'C4'),
         ]),
         startingV2,
-        'HitAlignedExtremumsHitTargets<VERTICAL:(C3,C4)>',
+        'HitAlignedExtremumsHitTargets<VERTICAL:]C3,C4[>',
         [
             'C2',
             'C5',
@@ -176,7 +176,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.MISS, 'C2'),
         ]),
         startingV2,
-        'HitAlignedExtremumsHitTargets<VERTICAL:(C3,C4)>',
+        'HitAlignedExtremumsHitTargets<VERTICAL:]C3,C4[>',
         [
             'C5',
         ],
@@ -190,7 +190,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.HIT, 'C4'),
         ]),
         startingV2,
-        'HitAlignedExtremumsHitTargets<VERTICAL:(C3,C4)>',
+        'HitAlignedExtremumsHitTargets<VERTICAL:]C3,C4[>',
         [
             'C2',
             'C5',
@@ -205,7 +205,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.HIT, 'C5'),
         ]),
         startingV2,
-        'HitAlignedGapsHitTargets<VERTICAL:(C3,C5)>',
+        'HitAlignedGapsHitTargets<VERTICAL:]C3,C5[>',
         [
             'C4',
         ],
@@ -402,7 +402,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.HIT, 'B6'),
         ]),
         startingV4,
-        'HitAlignedGapsHitTargets<VERTICAL:(B2,B6)>',
+        'HitAlignedGapsHitTargets<VERTICAL:]B2,B6[>',
         [
             'B3',
             'B4',
@@ -438,7 +438,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.HIT, 'D5'),
         ]),
         startingV4,
-        'HitAlignedGapsHitTargets<VERTICAL:(D2,D5)>',
+        'HitAlignedGapsHitTargets<VERTICAL:]D2,D5[>',
         [
             'D3',
             'D4',
@@ -556,7 +556,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.MISS, 'F2'),
         ]),
         startingV4,
-        'HitAlignedExtremumsHitTargets<VERTICAL:(D3,D4,D5,D6,D7)>',
+        'HitAlignedExtremumsHitTargets<VERTICAL:]D3,D4,D5,D6,D7]>',
         ['D2'],
     );
 
@@ -589,7 +589,7 @@ function* provideHitChoices(): Generator<HitChoicesSet> {
             createMoves(HitResponse.MISS, 'A9'),
         ]),
         startingV4,
-        'HitAlignedExtremumsHitTargets<VERTICAL:(A5,A6,A7,A8)>',
+        'HitAlignedExtremumsHitTargets<VERTICAL:]A5,A6,A7,A8]>',
         ['A4'],
     );
 


### PR DESCRIPTION
- Add a way to express that an extremum has been removed (via the symbol `RemovedNextExtremum`)
- Conserve the removed extremum when creating a new alignment from another one
- Add a way to add a coordinate to an existing alignment
- Add a way to check if any of the given coordinates belong to the alignment
- Improve string representation to reflect on whether there is a next head or next tail